### PR TITLE
Add initial cloud-native document-conversion architecture draft and capture public anonymous access decision

### DIFF
--- a/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
+++ b/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE DESCRIPTION
 
-The response must provide one or more architectural component, adhering to this format and describes the solution.
+The response provides an architectural component breakdown for a cloud-native document-conversion application.
 
 
 # PROBLEM STATEMENT
@@ -10,82 +10,265 @@ The response must provide one or more architectural component, adhering to this 
 - System:
   - We want to design a cloud-native, document-conversion application.
 - Users / actors:
-  - Browser-based users on the web accessing a website to convert files to different formats
+  - Browser-based users on the web accessing a website to convert files to different formats.
 - Primary outcome:
-  - Allows a host of conversion for different common filestypes
+  - Allows a host of conversion for different common file types.
 
 ## Scope boundaries
 
 - In scope:
-  - Common text files formats such as docx, docs, markdown, raw text, PDF, rst...
-  - Common geo files such as gpx, kml, kmz, geojson
+  - Common text file formats such as docx, docs, markdown, raw text, PDF, rst.
+  - Common geo files such as gpx, kml, kmz, geojson.
 - Out of scope:
-  - Videos, photos, audio and media files
+  - Videos, photos, audio and media files.
 
 ## Assumptions
 
-- The application will live in the cloud
-- users with upload their files via a web browser
-- they will get their files back via file download after the conversion is finished
+- The application will live in the cloud.
+- Users upload their files via a web browser.
+- Users get their files back via file download after the conversion is finished.
+- The service is publicly accessible and does not require user authentication.
 
 ## Architectural components
 
-Repeat & fill this template as needed. Follow the numbering convention.
-
-### 10 — <Component name>
+### 10 — Web Conversion Experience
 
 - Category:
-  - <client / domain service / orchestration / identity and access / data persistence / messaging / external integration / observability / other> 
+  - client
 - Purpose:
-  - <why this exists>
+  - Provide the browser-based interface for file submission, conversion configuration, progress tracking, and result retrieval.
 - Responsibilities:
-  - <responsibility>
+  - Accept user file selections and conversion preferences.
+  - Initiate conversion jobs and display job lifecycle state.
+  - Offer download actions when conversion completes.
+  - Surface validation, error, and quota messages in user-friendly form.
 - Interfaces:
   - Incoming:
-    - <requests / commands / events / user actions / upstream inputs>
+    - User actions (upload file, select source/target format, submit conversion, request download).
   - Outgoing:
-    - <responses / commands / events / downstream outputs>
+    - Requests to job intake and access-control components.
+    - Polling or subscription requests for job status updates.
 - Data / state:
-  - <what data or state this component owns, reads, writes, persists, or exposes>
+  - Session-scoped UI state (selected files, selected target format, job IDs).
+  - Optional persisted user preferences.
 - Interactions:
   - User-facing:
-    - <if applicable>
+    - Primary entry point for all conversion workflows.
   - Internal synchronous:
-    - <if applicable>
+    - Sends job submission and status requests.
   - Internal asynchronous:
-    - <if applicable>
+    - Receives status-change notifications when available.
 - Security / access considerations:
-  - <authentication / authorization / trust boundary / sensitive data notes>
+  - Treats all sessions as anonymous and applies public-use safeguards.
+  - Avoids exposing internal identifiers and sensitive metadata.
 - Observability / operational considerations:
-  - <logging / monitoring / auditability / failure visibility / admin concerns>
+  - Captures user flow metrics (submission attempts, completion rates, errors).
+  - Emits client-side diagnostic events for failed actions.
 - Dependencies:
-  - <Components IDs>
+  - 20
+  - 30
 - Constraints / notes:
-  - <important remarks>
+  - Must handle large uploads gracefully with progress feedback.
+
+### 20 — Job Intake and Lifecycle API
+
+- Category:
+  - orchestration
+- Purpose:
+  - Provide a stable API boundary for job creation, validation, lifecycle management, and result access.
+- Responsibilities:
+  - Validate submitted requests against supported conversion pairs and policy limits.
+  - Register conversion jobs and assign lifecycle states.
+  - Coordinate with storage, execution orchestration, and notification capabilities.
+  - Expose job status and result metadata to callers.
+- Interfaces:
+  - Incoming:
+    - Job submission requests from component 10.
+    - Job status/result requests from component 10.
+    - Completion/failure callbacks from component 40.
+  - Outgoing:
+    - File storage requests to component 30.
+    - Conversion execution commands to component 40.
+    - Notification triggers to component 50.
+- Data / state:
+  - Job records (requested conversion, owner context, lifecycle status, timestamps).
+  - Validation outcomes and failure reasons.
+- Interactions:
+  - User-facing:
+    - Indirectly user-facing through API responses.
+  - Internal synchronous:
+    - Validation and status queries.
+  - Internal asynchronous:
+    - Job dispatch and completion event handling.
+- Security / access considerations:
+  - Enforces submit and retrieval permissions.
+  - Ensures job and artifact access is mediated through short-lived, non-enumerable job references for anonymous users.
+- Observability / operational considerations:
+  - Emits lifecycle events and API latency/error metrics.
+  - Supports traceable job-level audit records.
+- Dependencies:
+  - 30
+  - 40
+  - 50
+- Constraints / notes:
+  - Must remain format-agnostic and avoid embedding converter-specific logic.
+
+### 30 — File and Artifact Management
+
+- Category:
+  - data persistence
+- Purpose:
+  - Store uploaded source files, generated outputs, and related metadata with controlled access.
+- Responsibilities:
+  - Accept and persist input files.
+  - Persist converted output artifacts.
+  - Provide controlled retrieval links/tokens for downloads.
+  - Enforce artifact retention and cleanup policies.
+- Interfaces:
+  - Incoming:
+    - Store/retrieve/delete requests from component 20.
+    - Read/write requests from component 40 during conversion execution.
+  - Outgoing:
+    - Storage references and metadata responses.
+    - Artifact lifecycle events to component 50.
+- Data / state:
+  - Binary file artifacts.
+  - Artifact metadata (owner, type, size, hash, retention expiry).
+- Interactions:
+  - User-facing:
+    - None directly; accessed via mediated API flows.
+  - Internal synchronous:
+    - Artifact reads/writes.
+  - Internal asynchronous:
+    - Cleanup and retention enforcement triggers.
+- Security / access considerations:
+  - Applies strict access scoping by job/user context.
+  - Ensures sensitive file contents are protected in transit and at rest.
+- Observability / operational considerations:
+  - Tracks storage growth, artifact retrieval latency, and cleanup outcomes.
+  - Captures integrity-check failures and anomalous access attempts.
+- Dependencies:
+  - 50
+- Constraints / notes:
+  - Must support temporary artifact lifecycle and predictable expiration behavior.
+
+### 40 — Conversion Execution Orchestrator
+
+- Category:
+  - domain service
+- Purpose:
+  - Execute conversion jobs by selecting a suitable conversion path and running the transformation workload.
+- Responsibilities:
+  - Resolve requested source-target conversions to available conversion capabilities.
+  - Run conversion jobs in isolated execution contexts.
+  - Produce deterministic conversion outputs and execution diagnostics.
+  - Report success/failure outcomes to lifecycle management.
+- Interfaces:
+  - Incoming:
+    - Conversion execution commands from component 20.
+  - Outgoing:
+    - Artifact read/write calls to component 30.
+    - Completion/failure events to component 20 and component 50.
+- Data / state:
+  - Ephemeral execution state (job runtime context, progress markers).
+  - Conversion capability registry metadata.
+- Interactions:
+  - User-facing:
+    - None.
+  - Internal synchronous:
+    - Fetch input artifacts and write outputs.
+  - Internal asynchronous:
+    - Accept queued jobs and emit completion signals.
+- Security / access considerations:
+  - Applies strict workload isolation for untrusted input files.
+  - Restricts outbound interactions to approved internal boundaries.
+- Observability / operational considerations:
+  - Records execution duration, failure classifications, and conversion quality signals.
+  - Provides per-job diagnostics for support and postmortem analysis.
+- Dependencies:
+  - 30
+  - 50
+- Constraints / notes:
+  - Must handle variable workload durations and occasional conversion failures without affecting platform stability.
 - Principal alternative (optional)
-  - 1-2 sentence, do not systematically  include with all components. But when a there are strong reasons to consider 2 options as very close, describe here your 2nd best choice for this component.
+  - Split orchestration and execution into two architectural components if conversion capability diversity or throughput requirements become significantly higher.
+
+### 50 — Platform Security, Policy, and Operations Backbone
+
+- Category:
+  - observability
+- Purpose:
+  - Provide shared cross-cutting capabilities for identity context, policy enforcement, monitoring, audit, and operational governance.
+- Responsibilities:
+  - Evaluate quota/rate policies for submissions and downloads in a public, anonymous access model.
+  - Enforce abuse-prevention and request-throttling controls without relying on user accounts.
+  - Aggregate logs, metrics, traces, and audit records across components.
+  - Raise operational alerts and support incident investigation.
+- Interfaces:
+  - Incoming:
+    - Policy check requests and telemetry streams from components 10, 20, 30, 40.
+  - Outgoing:
+    - Policy decisions and enforcement signals.
+    - Alerts, dashboards, and audit exports for operators.
+- Data / state:
+  - Security policy definitions and quota rules.
+  - Centralized telemetry and audit trails.
+- Interactions:
+  - User-facing:
+    - None directly.
+  - Internal synchronous:
+    - Policy decision points.
+  - Internal asynchronous:
+    - Continuous telemetry ingestion and alerting.
+- Security / access considerations:
+  - Serves as policy authority and audit source of truth.
+  - Must protect operational and audit data from unauthorized access.
+- Observability / operational considerations:
+  - Ensures end-to-end visibility of request path and conversion lifecycle.
+  - Supports compliance evidence generation and abuse detection.
+- Dependencies:
+  - None
+- Constraints / notes:
+  - Should remain reusable across future workflow modes and product features.
 
 ## System interaction summary
 
 - Primary request / control paths:
-  - <summary>
+  - Users submit a conversion via component 10, which is validated and registered by component 20, then dispatched to component 40.
+  - Users query job status via component 10 and component 20 until completion.
+  - Users retrieve converted outputs through component 10 and mediated artifact access from component 30.
 - Primary data flows:
-  - <summary>
+  - Input files flow from component 10 through component 20 into component 30.
+  - Conversion executor component 40 reads inputs from component 30 and writes transformed outputs back to component 30.
+  - Job metadata and status transitions persist through component 20.
 - Primary event flows:
-  - <summary>
+  - Component 20 emits job dispatch events toward component 40.
+  - Component 40 emits completion/failure events back to component 20.
+  - Components 20/30/40 emit telemetry and policy-relevant events to component 50.
 
 ## System-wide concerns
 
 - Security and access control:
-  - <items>
+  - Treat uploaded files as untrusted content across all processing steps.
+  - Enforce least-privilege access between components and per-job data isolation.
+  - Prevent unauthorized artifact downloads via short-lived mediated access mechanisms.
 - Reliability and recovery:
-  - <items>
+  - Ensure idempotent job submission handling to tolerate retries.
+  - Support conversion job retry policies for transient failures.
+  - Maintain clear terminal states for failed conversions with actionable diagnostics.
 - Observability and operations:
-  - <items>
+  - Correlate traces by job ID across intake, storage, and execution.
+  - Maintain audit trails for submission, access, conversion completion, and deletion.
+  - Provide operator visibility on queue depth, conversion latency, and failure rates by format pair.
 - Performance and scalability:
-  - <items>
+  - Decouple intake from execution to absorb spikes in upload requests.
+  - Scale execution capacity independently from user-facing request handling.
+  - Optimize artifact lifecycle management to control storage growth.
 - Compliance / audit / governance:
-  - <items if relevant>
+  - Define retention defaults and deletion guarantees for uploaded and converted artifacts.
+  - Capture policy decision logs for quota and access enforcement.
 
 ## Open questions
-- <question requiring architectural decision>
+- What maximum upload size and conversion rate limits should be enforced for anonymous public usage?
+- What artifact expiration window should apply to uploaded and converted files in the public service?
+- Should download links be single-use or reusable until expiration for anonymous users?

--- a/vibeCoding/.architecture/HISTORY.md
+++ b/vibeCoding/.architecture/HISTORY.md
@@ -24,16 +24,16 @@
 
 ## Resolved issues
 
-- YYYY-MM-DD — ISSUE-001: <title>
-  - Resolution: <1–2 lines>
-  - Notes: <optional>
+- 2026-03-06 — Arch-0.1: Baseline access and retention policy model
+  - Resolution: Access model resolved as public and unauthenticated; architecture updated to remove account-based assumptions.
+  - Notes: Detailed quota and artifact expiration settings remain open tuning items.
 
 ## Architectural decisions
 <!-- Keep only decisions worth preserving across revisions. -->
-- YYYY-MM-DD: <decision>
-  - Architectural components IDs (if relevant): []
-  - Rationale: <1–2 lines>
-  - Impact: <what parts of the architecture this affects>
+- 2026-03-06: Use a public anonymous access model (no authentication requirement)
+  - Architectural components IDs (if relevant): [10, 20, 30, 50]
+  - Rationale: Product direction is a publicly accessible conversion utility that supports upload-and-download workflows without accounts.
+  - Impact: Access controls rely on mediated job references, retention policy, and abuse/throttling safeguards rather than identity-based authorization.
 
 ## Superseded assumptions / changes
 <!-- Optional. Use when previous assumptions were later invalidated. -->

--- a/vibeCoding/.architecture/PLAN.md
+++ b/vibeCoding/.architecture/PLAN.md
@@ -38,21 +38,26 @@ Each item should contain:
 
 ## Active architecture questions
 
-### Arch-0.0 — <short title>
+### Arch-0.1 — Baseline access and retention policy model
 
-- Type: <CLARIFICATION | DECISION | INVESTIGATION | ASSUMPTION_VALIDATION | RISK_REVIEW>
-- Status: <OPEN | IN_PROGRESS | BLOCKED | DECISION_REQUIRED | RESOLVED>
+- Type: DECISION
+- Status: RESOLVED
 - Related system / draft:
-  - <system name or architecture draft identifier>
+  - Cloud-native document conversion architecture (Arch.0.1)
 - Why it matters:
-  - <why this question materially affects the architecture>
+  - Submission quotas, download sharing, and job-history retention strongly affect security boundaries, storage lifecycle, and user experience expectations.
 - Known options / hypotheses:
-  - <option or hypothesis>
+  - Strict temporary model: anonymous-first, no sharing, short retention windows.
+  - Hybrid model: optional accounts with higher quotas and limited-duration sharing links.
+  - Account-centric model: authenticated usage required for persistent history and stronger access controls.
 - Required input / evidence:
-  - <what information, analysis, or human decision is needed>
+  - Received: users confirmed the service is public and unauthenticated.
+  - Remaining: baseline retention/deletion window and link behavior tuning.
 - Resolution criteria:
-  - <what must be true for this item to be considered resolved>
+  - Decision on access model approved and reflected in architecture assumptions and component security considerations.
 - Affected sections:
-  - <component ids / architecture sections / document paths>
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` (Assumptions, Components 20/30/50, Open questions)
+  - `.architecture/STATE.md` (Active issues)
 - Notes:
-  - <optional>
+  - Resolution: choose a public, anonymous access model with no account authentication.
+  - Follow-up details (rate limits, expiration windows, link semantics) remain as open policy tuning items.

--- a/vibeCoding/.architecture/STATE.md
+++ b/vibeCoding/.architecture/STATE.md
@@ -1,6 +1,6 @@
 # STATE
 
-This file keeps track of architectural discussions. Mostly when tricker issues needs sorting with back & forth, or when multiple approaches would meet the objectives and the agent prefers to obtain input. 
+This file keeps track of architectural discussions. Mostly when tricker issues needs sorting with back & forth, or when multiple approaches would meet the objectives and the agent prefers to obtain input.
 
 ## Session read order
 
@@ -19,30 +19,30 @@ This file keeps track of architectural discussions. Mostly when tricker issues n
 ## Current focus
 
 - Revision ID: Arch.0.1
-- Status: NOT_STARTED  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+- Status: IN_REVIEW  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
 
 ## Objective (current draft)
-<!-- 1 sentence. Keep aligned with `.architecture/ARCHITECTURE_DESCRIPTION.md`. -->
+Create a first-pass architecture draft for a cloud-native document conversion system covering text and geo file types.
 
 ## Active assumptions / constraints
-<!-- Keep only the assumptions or constraints that materially affect the current architecture draft. -->
-- <assumption or constraint>
+- The architecture must avoid concrete technology or vendor choices.
+- End users interact only through a web browser flow.
+- Media conversion use cases (video/audio/images) remain out of scope.
 
 ## Work log (current session)
-<!-- Append-only bullets for what changed and why. Prefer file/section references. -->
-- YYYY-MM-DD: <change made and reason>
+- 2026-03-06: Produced initial architecture component draft in `.architecture/ARCHITECTURE_DESCRIPTION.md`, including system-wide concerns and open questions for review.
+- 2026-03-06: Updated workflow flags and active issue state to request human review on unresolved policy and retention decisions.
+- 2026-03-06: Applied human decision for Arch-0.1: public anonymous access with no authentication requirement.
 
 ## Workflow state
-<!-- Dispatcher flags. Checked = active/needed. Cleared once handled. -->
-- [ ] PROBLEM_CLARIFIED
-- [ ] DRAFT_CREATED
-- [ ] HUMAN_REVIEW_REQUIRED
-- [ ] DECISIONS_CAPTURED
+- [x] PROBLEM_CLARIFIED
+- [x] DRAFT_CREATED
+- [x] HUMAN_REVIEW_REQUIRED
+- [x] DECISIONS_CAPTURED
 
 ## Active issues
-<!-- Keep only active issues here. Move resolved items to HISTORY.md. -->
-- [ ] Arch.0.1: <short title>
+- [x] Arch.0.1: Baseline policy and retention decisions required
   - Impact: QUESTION <!-- QUESTION | MINOR | MAJOR | BLOCKER -->
-  - Status: NOT_STARTED <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
-  - Unblock condition: <what must be true to proceed>
-  - Notes: <optional context>
+  - Status: DONE <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+  - Unblock condition: None (resolved by human decision: public anonymous usage, no authentication).
+  - Notes: Resolution captured in PLAN item Arch-0.1 and HISTORY.


### PR DESCRIPTION
### Motivation
- Provide a first-pass architecture for a cloud-native document-conversion application covering text and geo file types.
- Capture key assumptions and system-wide concerns (security, reliability, observability, performance) to guide implementation decisions.
- Record and lock down the access model as a public, anonymous service to avoid account-based complexity for the baseline.

### Description
- Replace and expand `/.architecture/ARCHITECTURE_DESCRIPTION.md` with a detailed component breakdown (components `10`, `20`, `30`, `40`, `50`) describing purpose, interfaces, responsibilities, dependencies, and constraints.
- Update `/.architecture/PLAN.md` to create and resolve `Arch-0.1` (Baseline access and retention policy model) and surface remaining open tuning questions about quotas and retention windows.
- Amend `/.architecture/HISTORY.md` to record the resolved decision (public anonymous access) and add an architecture draft entry for the baseline model.
- Update `/.architecture/STATE.md` to reflect the draft `Arch.0.1` status as `IN_REVIEW`, add worklog entries, and mark the decision items as captured.

### Testing
- No automated tests were run because this change is documentation-only and does not modify executable code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2caea690832eab469ad6e427d7af)