### PR TITLE
Add initial architecture draft and decision backlog

### DIFF
--- a/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
+++ b/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
@@ -1,91 +1,252 @@
 # ARCHITECTURE DESCRIPTION
 
-The response must provide one or more architectural component, adhering to this format and describes the solution.
+## PROBLEM STATEMENT
 
-
-# PROBLEM STATEMENT
-
-## Objective
+### Objective
 
 - System:
   - We want to design a cloud-native, document-conversion application.
 - Users / actors:
-  - Browser-based users on the web accessing a website to convert files to different formats
+  - Browser-based users on the web accessing a website to convert files to different formats.
 - Primary outcome:
-  - Allows a host of conversion for different common filestypes
+  - Allow users to upload supported documents and retrieve converted output in a target format.
 
-## Scope boundaries
+### Scope boundaries
 
 - In scope:
-  - Common text files formats such as docx, docs, markdown, raw text, PDF, rst...
-  - Common geo files such as gpx, kml, kmz, geojson
+  - Common text file formats such as docx, docs, markdown, raw text, PDF, and rst.
+  - Common geo files such as gpx, kml, kmz, and geojson.
 - Out of scope:
-  - Videos, photos, audio and media files
+  - Videos, photos, audio, and other media files.
 
-## Assumptions
+### Assumptions
 
-- The application will live in the cloud
-- users with upload their files via a web browser
-- they will get their files back via file download after the conversion is finished
+- The application will run in the cloud.
+- Users upload files through a browser workflow.
+- Users download converted files after processing completes.
+- Uploaded source files and generated outputs are retained only for a limited lifecycle window.
 
 ## Architectural components
 
-Repeat & fill this template as needed. Follow the numbering convention.
-
-### 10 — <Component name>
+### 10 — Web Conversion Experience
 
 - Category:
-  - <client / domain service / orchestration / identity and access / data persistence / messaging / external integration / observability / other> 
+  - client
 - Purpose:
-  - <why this exists>
+  - Provide an intuitive browser experience for upload, conversion tracking, and download.
 - Responsibilities:
-  - <responsibility>
+  - Capture user conversion intent (source file + target format).
+  - Validate basic client-side constraints (file size, extension, required fields).
+  - Present job status and downloadable output links.
 - Interfaces:
   - Incoming:
-    - <requests / commands / events / user actions / upstream inputs>
+    - User actions (file select, target format selection, submit, download request).
   - Outgoing:
-    - <responses / commands / events / downstream outputs>
+    - Conversion submission requests to component 20.
+    - Status polling or subscription requests to component 20.
 - Data / state:
-  - <what data or state this component owns, reads, writes, persists, or exposes>
+  - Ephemeral UI state for selected file, requested output type, and latest job status.
 - Interactions:
   - User-facing:
-    - <if applicable>
+    - Direct web interface for upload, progress feedback, and result retrieval.
   - Internal synchronous:
-    - <if applicable>
+    - Request/response calls to component 20 for job creation and status.
   - Internal asynchronous:
-    - <if applicable>
+    - Optional status updates delivered from component 20.
 - Security / access considerations:
-  - <authentication / authorization / trust boundary / sensitive data notes>
+  - Enforce authenticated sessions where required.
+  - Avoid exposing internal identifiers beyond scoped job references.
 - Observability / operational considerations:
-  - <logging / monitoring / auditability / failure visibility / admin concerns>
+  - Capture client error telemetry and submission failures.
 - Dependencies:
-  - <Components IDs>
+  - 20
 - Constraints / notes:
-  - <important remarks>
+  - Must remain responsive when conversion throughput is high.
+
+### 20 — Conversion Access and Orchestration Gateway
+
+- Category:
+  - orchestration
+- Purpose:
+  - Serve as the front-door API and control-plane for conversion jobs.
+- Responsibilities:
+  - Validate incoming requests against supported source/target combinations.
+  - Create and track conversion job lifecycle states.
+  - Coordinate file intake, processing dispatch, and result publication.
+  - Expose status and retrieval metadata to clients.
+- Interfaces:
+  - Incoming:
+    - Conversion submission and status requests from component 10.
+  - Outgoing:
+    - Commands to component 30 to execute conversion.
+    - Read/write operations to component 40 for file access and lifecycle updates.
+    - Structured events and metrics to component 50.
+- Data / state:
+  - Job metadata: requester identity, source/target types, lifecycle state, timestamps, and output references.
+- Interactions:
+  - User-facing:
+    - Indirectly, through API responses consumed by component 10.
+  - Internal synchronous:
+    - Metadata reads/writes with component 40.
+  - Internal asynchronous:
+    - Job dispatch and completion notifications with component 30.
+- Security / access considerations:
+  - Enforce authorization checks on job creation and file retrieval.
+  - Issue scoped access tokens/links for temporary file transfers.
+- Observability / operational considerations:
+  - Emit job-state transition logs and latency distributions.
+  - Provide failure reason classification for support and triage.
+- Dependencies:
+  - 30, 40, 50
+- Constraints / notes:
+  - Must support idempotent submission to handle retries safely.
+
+### 30 — Conversion Processing Engine
+
+- Category:
+  - domain service
+- Purpose:
+  - Execute the actual conversion of supported document types into requested target formats.
+- Responsibilities:
+  - Resolve the proper conversion route based on source and target format.
+  - Perform content transformation and validation of output integrity.
+  - Return conversion results and structured processing errors.
+- Interfaces:
+  - Incoming:
+    - Conversion execution commands from component 20.
+  - Outgoing:
+    - Processing results and status updates to component 20.
+    - Operational telemetry to component 50.
+- Data / state:
+  - Temporary in-process state and conversion artifacts during job execution.
+- Interactions:
+  - User-facing:
+    - None.
+  - Internal synchronous:
+    - Fetch source and store output through component 40 (directly or brokered by component 20).
+  - Internal asynchronous:
+    - Consume queued work and emit completion/failure events.
+- Security / access considerations:
+  - Process untrusted input in an isolated execution boundary.
+  - Restrict execution capabilities to prevent unsafe file behaviors.
+- Observability / operational considerations:
+  - Emit per-format success/failure metrics and processing duration.
+  - Track retry attempts and terminal failure reasons.
+- Dependencies:
+  - 40, 50
+- Constraints / notes:
+  - Must handle heterogeneous file-size and format complexity characteristics.
 - Principal alternative (optional)
-  - 1-2 sentence, do not systematically  include with all components. But when a there are strong reasons to consider 2 options as very close, describe here your 2nd best choice for this component.
+  - Use format-specialized processing domains per document family instead of a unified engine if scalability and isolation requirements diverge significantly.
+
+### 40 — File and Job State Store
+
+- Category:
+  - data persistence
+- Purpose:
+  - Persist uploaded source files, generated outputs, and authoritative job metadata.
+- Responsibilities:
+  - Store and retrieve source and converted files.
+  - Maintain lifecycle metadata and retention policies.
+  - Enforce controlled deletion after retention windows.
+- Interfaces:
+  - Incoming:
+    - Read/write/update requests from components 20 and 30.
+  - Outgoing:
+    - Access outcomes and metadata references to components 20 and 30.
+- Data / state:
+  - Source documents, converted artifacts, job records, and retention schedules.
+- Interactions:
+  - User-facing:
+    - None directly.
+  - Internal synchronous:
+    - File and metadata operations from orchestration and processing components.
+  - Internal asynchronous:
+    - Lifecycle expiration actions and deletion audit events.
+- Security / access considerations:
+  - Encrypt sensitive file content at rest and in transit.
+  - Apply strict per-job access controls and expiration.
+- Observability / operational considerations:
+  - Audit read/write/delete access for sensitive files.
+  - Monitor storage utilization, object lifecycle lag, and retrieval latency.
+- Dependencies:
+  - 50
+- Constraints / notes:
+  - Retention behavior must balance user convenience with privacy minimization.
+
+### 50 — Platform Security and Operations Plane
+
+- Category:
+  - observability
+- Purpose:
+  - Provide cross-cutting security visibility, operational monitoring, and auditability.
+- Responsibilities:
+  - Collect logs, metrics, and traces across all components.
+  - Detect anomalous behavior and conversion abuse patterns.
+  - Maintain audit trails for job access and file handling events.
+- Interfaces:
+  - Incoming:
+    - Telemetry streams and audit events from components 20, 30, and 40.
+  - Outgoing:
+    - Alerts, dashboards, and operational reports to administrators.
+- Data / state:
+  - Time-series operational data, structured logs, and immutable audit records.
+- Interactions:
+  - User-facing:
+    - None for end users; administrative insight only.
+  - Internal synchronous:
+    - Administrative query interfaces for operational review.
+  - Internal asynchronous:
+    - Event ingestion pipelines from platform components.
+- Security / access considerations:
+  - Protect audit logs from tampering and unauthorized access.
+  - Enforce least-privilege access for operational tooling.
+- Observability / operational considerations:
+  - Define SLO-aligned indicators (submission latency, success rate, time-to-download).
+  - Track queue depth and processor saturation trends.
+- Dependencies:
+  - None
+- Constraints / notes:
+  - Must support incident investigation with sufficient historical retention.
 
 ## System interaction summary
 
 - Primary request / control paths:
-  - <summary>
+  - User submits conversion request via component 10.
+  - Component 20 validates request, creates job metadata, and dispatches processing through component 30.
+  - Component 30 retrieves source content, performs conversion, and reports completion.
+  - Component 20 exposes completion status and downloadable artifact reference back to component 10.
 - Primary data flows:
-  - <summary>
+  - Source file ingestion into component 40.
+  - Converted output persistence in component 40.
+  - Job metadata progression maintained by component 20 and persisted in component 40.
 - Primary event flows:
-  - <summary>
+  - Job-created, job-started, job-succeeded, and job-failed lifecycle events.
+  - Storage lifecycle expiration and deletion audit events.
 
 ## System-wide concerns
 
 - Security and access control:
-  - <items>
+  - Untrusted file input handling and isolation is mandatory.
+  - Retrieval links or tokens should be scoped, short-lived, and revocable.
+  - Administrative and user access paths must remain separated.
 - Reliability and recovery:
-  - <items>
+  - Job orchestration should support retry with idempotency safeguards.
+  - Failures must surface actionable user-facing states (retry, unsupported, failed).
+  - Partial processing failures should not corrupt persisted source artifacts.
 - Observability and operations:
-  - <items>
+  - End-to-end correlation across submission, processing, and delivery must be available.
+  - Alerting should distinguish user-caused input errors from system degradation.
 - Performance and scalability:
-  - <items>
+  - Processing capacity must scale independently from the web interaction layer.
+  - Large and complex documents require controlled concurrency and backpressure.
 - Compliance / audit / governance:
-  - <items if relevant>
+  - File retention and deletion windows require explicit policy definition.
+  - Audit trails must cover upload, conversion execution, and download access.
 
 ## Open questions
-- <question requiring architectural decision>
+
+- What maximum file size and processing-time limits should define acceptable jobs?
+- Is anonymous usage allowed, or must every conversion be associated with an authenticated identity?
+- Should conversion processing be strictly asynchronous for all jobs, or can a synchronous fast-path be allowed for small files?
+- What retention period should apply to source and output files by default?

--- a/vibeCoding/.architecture/PLAN.md
+++ b/vibeCoding/.architecture/PLAN.md
@@ -38,21 +38,64 @@ Each item should contain:
 
 ## Active architecture questions
 
-### Arch-0.0 — <short title>
+### Arch-0.1 — Processing interaction model
 
-- Type: <CLARIFICATION | DECISION | INVESTIGATION | ASSUMPTION_VALIDATION | RISK_REVIEW>
-- Status: <OPEN | IN_PROGRESS | BLOCKED | DECISION_REQUIRED | RESOLVED>
+- Type: DECISION
+- Status: DECISION_REQUIRED
 - Related system / draft:
-  - <system name or architecture draft identifier>
+  - Cloud-native document-conversion architecture (Arch.0.1)
 - Why it matters:
-  - <why this question materially affects the architecture>
+  - Determines whether users always receive deferred job handling or can receive immediate results for small/quick conversions.
 - Known options / hypotheses:
-  - <option or hypothesis>
+  - Fully asynchronous conversion flow for all requests.
+  - Hybrid flow: synchronous fast path under defined thresholds plus asynchronous fallback.
 - Required input / evidence:
-  - <what information, analysis, or human decision is needed>
+  - Product preference for UX responsiveness vs consistency and operational simplicity.
 - Resolution criteria:
-  - <what must be true for this item to be considered resolved>
+  - A single default processing model is selected and accepted for the architecture baseline.
 - Affected sections:
-  - <component ids / architecture sections / document paths>
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` components 10, 20, 30.
 - Notes:
-  - <optional>
+  - Choice affects client UX and orchestration complexity.
+
+### Arch-0.2 — User access posture
+
+- Type: DECISION
+- Status: DECISION_REQUIRED
+- Related system / draft:
+  - Cloud-native document-conversion architecture (Arch.0.1)
+- Why it matters:
+  - Identity requirements shape security boundaries, abuse controls, and audit obligations.
+- Known options / hypotheses:
+  - Authenticated users only.
+  - Anonymous conversion allowed with stricter rate/size limits.
+  - Mixed model with optional accounts.
+- Required input / evidence:
+  - Product and governance preference on friction, accountability, and abuse tolerance.
+- Resolution criteria:
+  - Accepted access posture with explicit guardrails.
+- Affected sections:
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` components 10, 20, 40, 50.
+- Notes:
+  - Also influences incident response and data-retention policies.
+
+### Arch-0.3 — File retention policy baseline
+
+- Type: CLARIFICATION
+- Status: OPEN
+- Related system / draft:
+  - Cloud-native document-conversion architecture (Arch.0.1)
+- Why it matters:
+  - Retention duration influences privacy risk, storage cost, and user retrieval expectations.
+- Known options / hypotheses:
+  - Immediate deletion after successful download.
+  - Short fixed retention window.
+  - Configurable retention by user tier.
+- Required input / evidence:
+  - Product policy and legal/compliance constraints.
+- Resolution criteria:
+  - Baseline retention rule and deletion behavior approved.
+- Affected sections:
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` components 20 and 40, system-wide governance concerns.
+- Notes:
+  - Must be aligned with audit-trail retention requirements.

--- a/vibeCoding/.architecture/STATE.md
+++ b/vibeCoding/.architecture/STATE.md
@@ -19,30 +19,38 @@ This file keeps track of architectural discussions. Mostly when tricker issues n
 ## Current focus
 
 - Revision ID: Arch.0.1
-- Status: NOT_STARTED  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+- Status: IN_REVIEW  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
 
 ## Objective (current draft)
-<!-- 1 sentence. Keep aligned with `.architecture/ARCHITECTURE_DESCRIPTION.md`. -->
+Produce an initial architecture draft for a cloud-native web document-conversion system covering major components, interfaces, and cross-cutting concerns.
 
 ## Active assumptions / constraints
-<!-- Keep only the assumptions or constraints that materially affect the current architecture draft. -->
-- <assumption or constraint>
+
+- The architecture remains implementation-agnostic and avoids naming specific products.
+- Conversion scope includes common text and geo formats only.
+- Upload and download are browser-mediated user interactions.
 
 ## Work log (current session)
-<!-- Append-only bullets for what changed and why. Prefer file/section references. -->
-- YYYY-MM-DD: <change made and reason>
+
+- 2026-03-06: Created first complete architectural component draft in `.architecture/ARCHITECTURE_DESCRIPTION.md` based on the provided problem statement.
+- 2026-03-06: Raised unresolved architectural decision items in `.architecture/PLAN.md` for workflow mode, identity model, and retention policy.
 
 ## Workflow state
-<!-- Dispatcher flags. Checked = active/needed. Cleared once handled. -->
-- [ ] PROBLEM_CLARIFIED
-- [ ] DRAFT_CREATED
-- [ ] HUMAN_REVIEW_REQUIRED
+
+- [x] PROBLEM_CLARIFIED
+- [x] DRAFT_CREATED
+- [x] HUMAN_REVIEW_REQUIRED
 - [ ] DECISIONS_CAPTURED
 
 ## Active issues
-<!-- Keep only active issues here. Move resolved items to HISTORY.md. -->
-- [ ] Arch.0.1: <short title>
+
+- [ ] Arch.0.1: Processing model decision (synchronous vs asynchronous fast path)
   - Impact: QUESTION <!-- QUESTION | MINOR | MAJOR | BLOCKER -->
-  - Status: NOT_STARTED <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
-  - Unblock condition: <what must be true to proceed>
-  - Notes: <optional context>
+  - Status: IN_REVIEW <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+  - Unblock condition: Human reviewer selects preferred processing interaction model.
+  - Notes: Impacts orchestration interface design, user status UX, and scalability behavior.
+- [ ] Arch.0.2: Access model decision (authenticated-only vs anonymous allowed)
+  - Impact: MAJOR <!-- QUESTION | MINOR | MAJOR | BLOCKER -->
+  - Status: IN_REVIEW <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+  - Unblock condition: Human reviewer confirms required identity and access posture.
+  - Notes: Directly affects security boundary and auditability requirements.


### PR DESCRIPTION
### Motivation
- Provide an initial architecture draft for a cloud-native document-conversion application to drive review in architecture design mode.
- Capture major components, responsibilities, interfaces, and system-wide concerns without prescribing implementation details.
- Record open architecture questions that require human decisions to proceed.

### Description
- Added and populated `vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md` with problem statement, assumptions, five top-level components (10/20/30/40/50), interaction summaries, system-wide concerns, and open questions.
- Updated `vibeCoding/.architecture/STATE.md` to set `Revision ID: Arch.0.1` to `IN_REVIEW`, include the session work log, active assumptions, and explicit active issues requiring decisions.
- Populated `vibeCoding/.architecture/PLAN.md` with a decision backlog containing `Arch-0.1` (processing interaction model), `Arch-0.2` (user access posture), and `Arch-0.3` (file retention policy) including options and resolution criteria.

### Testing
- Ran `git -C /workspace/testProject1 diff --check` which returned clean results and no whitespace errors.
- Ran `git -C /workspace/testProject1 status --short` to verify the expected working-tree changes were present and the files staged for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3fdcaebc832eab2781ebcdfc0122)