### PR TITLE
Add initial architecture-mode draft for document conversion

### DIFF
--- a/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
+++ b/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
@@ -1,91 +1,319 @@
 # ARCHITECTURE DESCRIPTION
 
-The response must provide one or more architectural component, adhering to this format and describes the solution.
-
+The target system is a cloud-native document conversion platform where browser users upload files, request an output format, and download converted files when processing is complete.
 
 # PROBLEM STATEMENT
 
 ## Objective
 
 - System:
-  - We want to design a cloud-native, document-conversion application.
+  - Design a cloud-native document-conversion application.
 - Users / actors:
-  - Browser-based users on the web accessing a website to convert files to different formats
+  - Browser-based users accessing a website to convert files to different formats.
 - Primary outcome:
-  - Allows a host of conversion for different common filestypes
+  - Reliable conversion of common text and geospatial document types with downloadable results.
 
 ## Scope boundaries
 
 - In scope:
-  - Common text files formats such as docx, docs, markdown, raw text, PDF, rst...
-  - Common geo files such as gpx, kml, kmz, geojson
+  - Common text formats (for example: docx-like documents, markdown-like text, plain text, PDF-like outputs, structured text variants).
+  - Common geospatial files (for example: track and feature data formats).
 - Out of scope:
-  - Videos, photos, audio and media files
+  - Video, image, and audio/media conversion.
 
 ## Assumptions
 
-- The application will live in the cloud
-- users with upload their files via a web browser
-- they will get their files back via file download after the conversion is finished
+- The system runs in a cloud environment.
+- Users submit files through a browser workflow.
+- Conversion is not guaranteed to complete instantly; asynchronous handling is allowed.
+- Users retrieve converted outputs through a secure download flow.
 
 ## Architectural components
 
-Repeat & fill this template as needed. Follow the numbering convention.
-
-### 10 — <Component name>
+### 10 — Web Conversion Interface
 
 - Category:
-  - <client / domain service / orchestration / identity and access / data persistence / messaging / external integration / observability / other> 
+  - client
 - Purpose:
-  - <why this exists>
+  - Provide end-user interaction for file submission, conversion request configuration, progress visibility, and result retrieval.
 - Responsibilities:
-  - <responsibility>
+  - Capture user file input and desired output type.
+  - Submit conversion requests and display job state.
+  - Trigger secure result download once conversion completes.
 - Interfaces:
   - Incoming:
-    - <requests / commands / events / user actions / upstream inputs>
+    - User actions (upload file, choose format, submit request, download output).
   - Outgoing:
-    - <responses / commands / events / downstream outputs>
+    - Request/response interactions with 20.
 - Data / state:
-  - <what data or state this component owns, reads, writes, persists, or exposes>
+  - Maintains ephemeral UI state for current request and status.
 - Interactions:
   - User-facing:
-    - <if applicable>
+    - Main application interface for conversion lifecycle.
   - Internal synchronous:
-    - <if applicable>
+    - Calls to 20 for request creation, status checks, and download initiation.
   - Internal asynchronous:
-    - <if applicable>
+    - Optional status refresh interactions with 20.
 - Security / access considerations:
-  - <authentication / authorization / trust boundary / sensitive data notes>
+  - Operates across an external trust boundary; requires authenticated session where applicable.
+  - Must avoid exposing raw storage access details to users.
 - Observability / operational considerations:
-  - <logging / monitoring / auditability / failure visibility / admin concerns>
+  - Tracks user-visible failures (validation errors, conversion failures, download errors).
 - Dependencies:
-  - <Components IDs>
+  - 20
 - Constraints / notes:
-  - <important remarks>
-- Principal alternative (optional)
-  - 1-2 sentence, do not systematically  include with all components. But when a there are strong reasons to consider 2 options as very close, describe here your 2nd best choice for this component.
+  - UI must support large-file progress feedback and clear failure messaging.
+
+### 20 — Conversion API and Access Boundary
+
+- Category:
+  - orchestration
+- Purpose:
+  - Provide a controlled entry point for all conversion operations and enforce access/security policies.
+- Responsibilities:
+  - Validate incoming requests and accepted format combinations.
+  - Authorize request operations and map user identity to conversion jobs.
+  - Issue upload/download intents and expose job status.
+  - Publish conversion jobs to 30.
+- Interfaces:
+  - Incoming:
+    - Requests from 10.
+    - Identity assertions from 60.
+  - Outgoing:
+    - Commands to 30.
+    - Read/write metadata interactions with 50.
+    - Download response metadata to 10.
+- Data / state:
+  - Owns request metadata, job identifiers, ownership mapping, and status snapshots.
+- Interactions:
+  - User-facing:
+    - Indirectly serves user operations through 10.
+  - Internal synchronous:
+    - Request validation and metadata operations with 50.
+  - Internal asynchronous:
+    - Job submission to 30 and receipt of status updates.
+- Security / access considerations:
+  - Enforces authentication/authorization and input validation.
+  - Ensures only authorized users can access produced outputs.
+- Observability / operational considerations:
+  - Emits structured request and lifecycle logs with job correlation identifiers.
+- Dependencies:
+  - 30, 50, 60, 80
+- Constraints / notes:
+  - Must remain stateless at compute level; persistent state is externalized.
+
+### 30 — Conversion Orchestration and Queueing
+
+- Category:
+  - messaging
+- Purpose:
+  - Decouple request intake from conversion execution and manage job dispatch.
+- Responsibilities:
+  - Accept conversion job commands from 20.
+  - Queue and dispatch jobs to available workers in 40.
+  - Manage retry signals and failure routing metadata.
+- Interfaces:
+  - Incoming:
+    - Job commands from 20.
+    - Worker result events from 40.
+  - Outgoing:
+    - Job assignments to 40.
+    - Status/progress events to 20 and 80.
+- Data / state:
+  - Owns in-flight queue state and delivery attempt metadata.
+- Interactions:
+  - User-facing:
+    - None.
+  - Internal synchronous:
+    - None required.
+  - Internal asynchronous:
+    - Event/command exchange with 20, 40, and 80.
+- Security / access considerations:
+  - Accepts commands only from trusted internal producers.
+  - Restricts worker consumption to authorized internal identities.
+- Observability / operational considerations:
+  - Tracks queue depth, dispatch latency, retry rates, and dead-letter counts.
+- Dependencies:
+  - 40, 80
+- Constraints / notes:
+  - Queue behavior must prevent starvation of smaller or interactive workloads.
+
+### 40 — Conversion Execution Workers
+
+- Category:
+  - domain service
+- Purpose:
+  - Perform file format transformation workloads.
+- Responsibilities:
+  - Fetch source files and conversion instructions.
+  - Execute conversion logic for supported text and geospatial formats.
+  - Persist output artifacts and publish success/failure events.
+- Interfaces:
+  - Incoming:
+    - Job assignments from 30.
+  - Outgoing:
+    - File read/write operations with 50.
+    - Completion/failure events to 30 and 80.
+- Data / state:
+  - Maintains transient execution state and conversion diagnostics.
+- Interactions:
+  - User-facing:
+    - None.
+  - Internal synchronous:
+    - Artifact reads/writes with 50.
+  - Internal asynchronous:
+    - Job consumption and result publication via 30.
+- Security / access considerations:
+  - Runs in an internal trust zone with least-privilege access to relevant files.
+  - Must isolate processing to prevent one request from accessing another request's data.
+- Observability / operational considerations:
+  - Captures per-job processing duration, error class, and resource utilization indicators.
+- Dependencies:
+  - 30, 50, 80
+- Constraints / notes:
+  - Workers must be horizontally scalable for burst processing demand.
+  - Unsupported conversion pairs should fail fast with explicit reason codes.
+
+### 50 — Conversion Artifact and Metadata Store
+
+- Category:
+  - data persistence
+- Purpose:
+  - Persist source artifacts, converted outputs, and job metadata used across the conversion lifecycle.
+- Responsibilities:
+  - Store uploaded input artifacts and generated outputs.
+  - Store job metadata (ownership, status, timestamps, conversion parameters).
+  - Apply retention and deletion policies for artifacts and metadata.
+- Interfaces:
+  - Incoming:
+    - Metadata reads/writes from 20.
+    - Artifact reads/writes from 40.
+  - Outgoing:
+    - Artifact and metadata access responses.
+- Data / state:
+  - Durable object-like artifact state and durable structured metadata.
+- Interactions:
+  - User-facing:
+    - None directly.
+  - Internal synchronous:
+    - Read/write interactions with 20 and 40.
+  - Internal asynchronous:
+    - Optional lifecycle event emissions to 80.
+- Security / access considerations:
+  - Separates user-visible download access from internal storage permissions.
+  - Encrypts sensitive data at rest and enforces controlled access paths.
+- Observability / operational considerations:
+  - Tracks storage growth, retention compliance, and retrieval latency.
+- Dependencies:
+  - 80
+- Constraints / notes:
+  - Must support large binary artifacts and predictable retrieval behavior.
+
+### 60 — Identity and Access Control Service
+
+- Category:
+  - identity and access
+- Purpose:
+  - Provide authentication assertions and authorization context for conversion operations.
+- Responsibilities:
+  - Authenticate end users and issue verified identity context.
+  - Provide permission checks for conversion and download actions.
+- Interfaces:
+  - Incoming:
+    - Authentication requests from 10.
+    - Identity validation requests from 20.
+  - Outgoing:
+    - Identity/authorization assertions to 20.
+- Data / state:
+  - Identity attributes, session assertions, and policy definitions.
+- Interactions:
+  - User-facing:
+    - Authentication steps where required.
+  - Internal synchronous:
+    - Identity verification exchanges with 20.
+  - Internal asynchronous:
+    - None required.
+- Security / access considerations:
+  - Defines trust boundary for user identity claims.
+  - Provides auditable authorization decisions.
+- Observability / operational considerations:
+  - Tracks sign-in failures, authorization denials, and anomaly indicators.
+- Dependencies:
+  - 80
+- Constraints / notes:
+  - Must support access revocation for active sessions and download entitlements.
+
+### 80 — Observability and Operational Control Plane
+
+- Category:
+  - observability
+- Purpose:
+  - Centralize monitoring, logging, tracing, alerting, and operational diagnostics.
+- Responsibilities:
+  - Collect telemetry from 20, 30, 40, 50, and 60.
+  - Correlate conversion jobs across components for incident triage.
+  - Provide operational dashboards and alert signals.
+- Interfaces:
+  - Incoming:
+    - Logs, metrics, and events from core components.
+  - Outgoing:
+    - Alerts and operational insights to platform operators.
+- Data / state:
+  - Time-series operational metrics, logs, and job-level traces.
+- Interactions:
+  - User-facing:
+    - None directly.
+  - Internal synchronous:
+    - Query interfaces used by operations workflows.
+  - Internal asynchronous:
+    - Telemetry ingestion from all relevant components.
+- Security / access considerations:
+  - Restricts operational data visibility to authorized operator roles.
+- Observability / operational considerations:
+  - Serves as the primary source for SLA/SLO and failure trend assessment.
+- Dependencies:
+  - None
+- Constraints / notes:
+  - Telemetry retention policy must support incident forensics and audit needs.
 
 ## System interaction summary
 
 - Primary request / control paths:
-  - <summary>
+  - Users interact with 10, which routes validated conversion requests through 20.
+  - 20 authorizes and registers jobs, then hands execution requests to 30.
+  - 30 dispatches work to 40; 40 writes outputs to 50 and returns result events.
+  - 20 exposes resulting status and download access back to 10.
 - Primary data flows:
-  - <summary>
+  - Source artifacts move from user upload (via 10/20) into 50.
+  - Conversion outputs are produced by 40 and persisted to 50.
+  - Metadata and status move between 20, 30, and 50.
 - Primary event flows:
-  - <summary>
+  - Job submission events flow 20 -> 30.
+  - Completion/failure events flow 40 -> 30 -> 20.
+  - Operational telemetry flows all core components -> 80.
 
 ## System-wide concerns
 
 - Security and access control:
-  - <items>
+  - Enforce authenticated access for job creation and output retrieval.
+  - Validate file type/size constraints at ingress.
+  - Apply least-privilege internal access between orchestration, workers, and storage.
 - Reliability and recovery:
-  - <items>
+  - Asynchronous queueing enables retry and failure isolation.
+  - Worker failures should not block intake path.
+  - Durable metadata/state in 50 supports restart and status reconstruction.
 - Observability and operations:
-  - <items>
+  - Job correlation IDs are required end-to-end.
+  - Alerting should cover queue backlog, conversion failure spikes, and degraded latency.
 - Performance and scalability:
-  - <items>
+  - Horizontal scaling for 40 handles variable conversion demand.
+  - Queue-based decoupling smooths bursts from user submissions.
+  - Storage and metadata layers must tolerate high concurrent reads for downloads.
 - Compliance / audit / governance:
-  - <items if relevant>
+  - Maintain conversion request and download audit trails.
+  - Retention/deletion policies must align with data lifecycle requirements.
 
 ## Open questions
-- <question requiring architectural decision>
+- What maximum file size and processing duration should define accepted service tiers?
+- Should anonymous conversions be allowed, or must all requests require authenticated identity?
+- What artifact retention window balances user convenience and storage/compliance constraints?

--- a/vibeCoding/.architecture/HISTORY.md
+++ b/vibeCoding/.architecture/HISTORY.md
@@ -8,35 +8,20 @@
 
 ## Completed architecture drafts
 <!-- Append entries as architecture drafts are completed, updated, or approved. -->
-- YYYY-MM-DD — <system or project name>
-  - Draft file: `.architecture/ARCHITECTURE_DESCRIPTION.md`
-  - Summary:
-    - <major architectural outcome>
-    - <major architectural outcome>
 
 ## Review history
 <!-- Use this for architecture revision rounds -->
-- YYYY-MM-DD — Review round <n>
-  - Architectural components IDs (if relevant): []
+- 2026-03-06 — Review round 1
+  - Architectural components IDs (if relevant): [10, 20, 30, 40, 50, 60, 80]
   - Feedback summary (e.g. from follow-up prompts etc.)
-    - <what changed or was requested>
-  - Result: <accepted | changes requested | blocked>
+    - Initial architecture draft created for cloud-native document conversion in architecture mode.
+    - Follow-up human input requested for identity policy, retention policy, and workload envelope.
+  - Result: changes requested
 
 ## Resolved issues
 
-- YYYY-MM-DD — ISSUE-001: <title>
-  - Resolution: <1–2 lines>
-  - Notes: <optional>
-
 ## Architectural decisions
 <!-- Keep only decisions worth preserving across revisions. -->
-- YYYY-MM-DD: <decision>
-  - Architectural components IDs (if relevant): []
-  - Rationale: <1–2 lines>
-  - Impact: <what parts of the architecture this affects>
 
 ## Superseded assumptions / changes
 <!-- Optional. Use when previous assumptions were later invalidated. -->
-- YYYY-MM-DD: <old assumption or prior direction>
-  - Replaced by: <new direction>
-  - Reason: <why it changed>

--- a/vibeCoding/.architecture/PLAN.md
+++ b/vibeCoding/.architecture/PLAN.md
@@ -38,21 +38,64 @@ Each item should contain:
 
 ## Active architecture questions
 
-### Arch-0.0 — <short title>
+### Arch-0.1 — Identity requirement for conversion requests
 
-- Type: <CLARIFICATION | DECISION | INVESTIGATION | ASSUMPTION_VALIDATION | RISK_REVIEW>
-- Status: <OPEN | IN_PROGRESS | BLOCKED | DECISION_REQUIRED | RESOLVED>
+- Type: DECISION
+- Status: DECISION_REQUIRED
 - Related system / draft:
-  - <system name or architecture draft identifier>
+  - Arch.0.1
 - Why it matters:
-  - <why this question materially affects the architecture>
+  - Authentication posture determines trust boundaries, abuse controls, and user ownership model for artifacts.
 - Known options / hypotheses:
-  - <option or hypothesis>
+  - Require authenticated users for all conversions.
+  - Allow anonymous conversions with stricter size/rate limits.
+  - Support both modes with policy-based gating.
 - Required input / evidence:
-  - <what information, analysis, or human decision is needed>
+  - Product decision on user onboarding friction versus abuse risk tolerance.
 - Resolution criteria:
-  - <what must be true for this item to be considered resolved>
+  - Explicit policy for who can submit requests and retrieve results.
 - Affected sections:
-  - <component ids / architecture sections / document paths>
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` (components 10, 20, 60; system-wide security concerns)
 - Notes:
-  - <optional>
+  - Current draft assumes authentication is available but not mandated.
+
+### Arch-0.2 — File retention and deletion policy
+
+- Type: DECISION
+- Status: DECISION_REQUIRED
+- Related system / draft:
+  - Arch.0.1
+- Why it matters:
+  - Retention windows impact storage cost, compliance exposure, and user experience for delayed downloads.
+- Known options / hypotheses:
+  - Short retention with mandatory immediate download.
+  - Configurable retention by service tier.
+  - User-controlled deletion with hard maximum retention.
+- Required input / evidence:
+  - Business and compliance requirements for stored customer files.
+- Resolution criteria:
+  - Defined default retention, max retention, and deletion guarantees.
+- Affected sections:
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` (component 50; compliance and reliability concerns)
+- Notes:
+  - Current draft marks retention as a system-wide concern without fixed thresholds.
+
+### Arch-0.3 — Service envelope for workload limits
+
+- Type: CLARIFICATION
+- Status: OPEN
+- Related system / draft:
+  - Arch.0.1
+- Why it matters:
+  - Max file size, expected throughput, and duration targets shape queueing, scaling, and SLA design.
+- Known options / hypotheses:
+  - Interactive-first envelope with lower file-size limits.
+  - Batch-friendly envelope with longer processing windows.
+- Required input / evidence:
+  - Product-level SLO expectations and anticipated usage profile.
+- Resolution criteria:
+  - Documented upper bounds for accepted file size and target completion profile.
+- Affected sections:
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` (components 30, 40, 50; performance and reliability concerns)
+- Notes:
+  - This clarification can be resolved before any component-level deep dive.

--- a/vibeCoding/.architecture/STATE.md
+++ b/vibeCoding/.architecture/STATE.md
@@ -19,30 +19,33 @@ This file keeps track of architectural discussions. Mostly when tricker issues n
 ## Current focus
 
 - Revision ID: Arch.0.1
-- Status: NOT_STARTED  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+- Status: IN_REVIEW  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
 
 ## Objective (current draft)
-<!-- 1 sentence. Keep aligned with `.architecture/ARCHITECTURE_DESCRIPTION.md`. -->
+Design a cloud-native architecture for browser-driven document conversion across text and geospatial formats with asynchronous processing and secure result retrieval.
 
 ## Active assumptions / constraints
 <!-- Keep only the assumptions or constraints that materially affect the current architecture draft. -->
-- <assumption or constraint>
+- Cloud-hosted deployment and browser-first interaction model.
+- Media conversion (audio/video/image) remains out of scope.
+- Architecture must stay technology-agnostic and role-based.
 
 ## Work log (current session)
 <!-- Append-only bullets for what changed and why. Prefer file/section references. -->
-- YYYY-MM-DD: <change made and reason>
+- 2026-03-06: Drafted initial architecture components and end-to-end interaction model in `.architecture/ARCHITECTURE_DESCRIPTION.md`.
+- 2026-03-06: Added open architectural questions and moved status to `IN_REVIEW` pending human feedback.
 
 ## Workflow state
 <!-- Dispatcher flags. Checked = active/needed. Cleared once handled. -->
-- [ ] PROBLEM_CLARIFIED
-- [ ] DRAFT_CREATED
-- [ ] HUMAN_REVIEW_REQUIRED
+- [x] PROBLEM_CLARIFIED
+- [x] DRAFT_CREATED
+- [x] HUMAN_REVIEW_REQUIRED
 - [ ] DECISIONS_CAPTURED
 
 ## Active issues
 <!-- Keep only active issues here. Move resolved items to HISTORY.md. -->
-- [ ] Arch.0.1: <short title>
+- [ ] Arch.0.1: Service policy decisions pending
   - Impact: QUESTION <!-- QUESTION | MINOR | MAJOR | BLOCKER -->
-  - Status: NOT_STARTED <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
-  - Unblock condition: <what must be true to proceed>
-  - Notes: <optional context>
+  - Status: IN_REVIEW <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+  - Unblock condition: Human review confirms constraints for authentication posture, retention window, and max workload profile.
+  - Notes: Decisions tracked in `.architecture/PLAN.md` as Arch-0.1 to Arch-0.3.


### PR DESCRIPTION
### Motivation
- Establish a technology-agnostic, role-based architecture for a cloud-native document conversion platform to guide design and review. 
- Capture scope, assumptions, major components, interactions, system-wide concerns, and open architecture questions that require product decisions. 

### Description
- Added a complete architecture draft in ` .architecture/ARCHITECTURE_DESCRIPTION.md` describing the system, scope, assumptions, the component breakdown (10, 20, 30, 40, 50, 60, 80), interactions, and open questions. 
- Created actionable backlog items in ` .architecture/PLAN.md` for identity policy, retention policy, and workload envelope tracked as `Arch-0.1` through `Arch-0.3`. 
- Updated ` .architecture/STATE.md` to reflect current focus (`Arch.0.1`) and set the draft status to `IN_REVIEW` with a short work log. 
- Recorded the initial review round and summary in ` .architecture/HISTORY.md` for traceability. 

### Testing
- Ran the whitespace/format check via `git diff --check` and it completed without reporting issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3fdcaebc832eab2781ebcdfc0122)