### PR TITLE
Add Arch.0.1 architecture baseline for cloud document conversion

### DIFF
--- a/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
+++ b/vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md
@@ -1,100 +1,304 @@
 # ARCHITECTURE DESCRIPTION
 
-The response must provide one or more architectural component, adhering to this format and describes the solution.
+## PROBLEM STATEMENT
 
-
-# PROBLEM STATEMENT
-
-## Objective
+### Objective
 
 - System:
-  - We want to design a cloud-native, document-conversion application.
+  - Cloud-native document-conversion application.
 - Users / actors:
-  - Browser-based users on the web accessing a website to convert files to different formats
+  - Browser-based users uploading and downloading files through a web experience.
 - Primary outcome:
-  - Allows a host of conversion for different common filestypes
+  - Convert common document and geospatial file types between supported formats.
 
-## Scope boundaries
+### Scope boundaries
 
 - In scope:
-  - Common text files formats such as docx, docs, markdown, raw text, PDF, rst...
-  - Common geo files such as gpx, kml, kmz, geojson
+  - Textual/document formats (for example: docx, docs, markdown, raw text, PDF, rst).
+  - Geospatial formats (for example: gpx, kml, kmz, geojson).
 - Out of scope:
-  - Videos, photos, audio and media files
+  - Video, photo, audio, and media conversion.
 
-## Assumptions
+### Assumptions
 
-- The application will live in the cloud
-- users with upload their files via a web browser
-- they will get their files back via file download after the conversion is finished
-- The application will be based on a micro-service architecture
-- The application will be developped incrementally. The development should emphasis a MVP approach
+- The application runs in a cloud environment.
+- Users upload files from a browser and retrieve converted outputs by download.
+- Architecture follows a microservice style.
+- Delivery is incremental with an MVP-first approach.
 
 ## Architectural components
 
-Repeat & fill this template as needed. Follow the numbering convention.
-
-### 10 — <Component name>
+### 10 — Web Experience and Session Gateway
 
 - Category:
-  - <client / domain service / orchestration / identity and access / data persistence / messaging / external integration / observability / other> 
+  - client
 - Purpose:
-  - <why this exists>
+  - Provide user-facing flows for file submission, conversion tracking, and result retrieval.
 - Responsibilities:
-  - <responsibility>
+  - Accept user file selection and conversion parameters.
+  - Validate basic client-side constraints before submission.
+  - Display conversion status and offer result download links.
+  - Manage user session context for request correlation.
 - Interfaces:
   - Incoming (one per flow)
-    - Type: <requests / commands / events / user actions / upstream inputs>
-    - Short description:
+    - Type: user actions
+    - Short description: User uploads source file, selects target format, and initiates conversion.
   - Outgoing:
-    - Type: <responses / commands / events / downstream outputs>
-    - Short description:
+    - Type: requests
+    - Short description: Sends conversion requests and polling/notification subscriptions to backend API surface.
 
 - Data / state:
-  - <what data or state this component owns, reads, writes, persists, or exposes>
+  - Temporary session state (job references, selected formats, UI status).
 - Interactions:
   - User-facing:
-    - <if applicable>
+    - Upload form, conversion options, progress feedback, and download action.
   - Internal synchronous:
-    - <if applicable>
+    - Calls Component 20 for job creation and status retrieval.
   - Internal asynchronous:
-    - <if applicable>
+    - Receives completion notifications originating from Component 20/30.
 - Security / access considerations:
-  - <authentication / authorization / trust boundary / sensitive data notes>
+  - Session authentication context, anti-abuse controls on upload attempts, and safe handling of transient file metadata.
 - Observability / operational considerations:
-  - <logging / monitoring / auditability / failure visibility / admin concerns>
+  - Client journey telemetry for drop-off points and conversion failure visibility.
 - Dependencies:
-  - <Components IDs>
+  - 20
 - Constraints / notes:
-  - <important remarks>
-- Principal alternative (optional)
-  - 1-2 sentence, do not systematically  include with all components. But when a there are strong reasons to consider 2 options as very close, describe here your 2nd best choice for this component.
+  - Must remain responsive for potentially long-running conversions.
 
-### System interaction summary
+### 20 — Conversion API and Workflow Coordinator
+
+- Category:
+  - orchestration
+- Purpose:
+  - Serve as entry point for conversion requests and coordinate the conversion lifecycle.
+- Responsibilities:
+  - Receive and validate conversion requests.
+  - Persist job metadata and lifecycle state transitions.
+  - Route jobs to appropriate conversion capability based on format pair.
+  - Publish job events and expose status/read models for clients.
+- Interfaces:
+  - Incoming (one per flow)
+    - Type: requests
+    - Short description: Receives job creation and status requests from Component 10.
+  - Outgoing:
+    - Type: commands/events/responses
+    - Short description: Issues conversion commands to Component 30, stores artifacts in Component 40, emits lifecycle events to Component 50, and returns status/results to Component 10.
+
+- Data / state:
+  - Conversion job records, state machine transitions, supported format catalog snapshot.
+- Interactions:
+  - User-facing:
+    - Indirectly supports user status and completion from API responses.
+  - Internal synchronous:
+    - Reads/writes job metadata through Component 40.
+  - Internal asynchronous:
+    - Emits and consumes job lifecycle events via Component 50.
+- Security / access considerations:
+  - Enforces authorization checks for job visibility and artifact retrieval scope.
+- Observability / operational considerations:
+  - End-to-end tracing across request-to-conversion lifecycle and SLA metrics by conversion pair.
+- Dependencies:
+  - 30, 40, 50, 60
+- Constraints / notes:
+  - Must remain stateless at runtime except for externally persisted workflow state.
+
+### 30 — Conversion Execution Services
+
+- Category:
+  - domain service
+- Purpose:
+  - Perform actual file format transformation within isolated execution units.
+- Responsibilities:
+  - Execute conversion logic per supported format pair.
+  - Validate source/target compatibility and report deterministic errors.
+  - Stream or stage produced outputs for durable storage.
+- Interfaces:
+  - Incoming (one per flow)
+    - Type: commands
+    - Short description: Receives conversion execution commands with source artifact references.
+  - Outgoing:
+    - Type: events/downstream outputs
+    - Short description: Returns conversion outcomes, error signals, and output artifact references.
+
+- Data / state:
+  - Ephemeral execution state, temporary working files, conversion capability registry.
+- Interactions:
+  - User-facing:
+    - None directly.
+  - Internal synchronous:
+    - Reads source artifacts and writes outputs through Component 40.
+  - Internal asynchronous:
+    - Sends completion/failure events to Component 50 for workflow continuation.
+- Security / access considerations:
+  - Strong execution isolation, untrusted file handling safeguards, and least-privilege access to artifacts.
+- Observability / operational considerations:
+  - Per-format success/failure rates, conversion duration, and error classification.
+- Dependencies:
+  - 40, 50
+- Constraints / notes:
+  - Must scale horizontally for bursty workloads and long-tail conversion durations.
+- Principal alternative (optional)
+  - A single monolithic conversion engine is possible for MVP speed, but independent execution services better support isolation and incremental format expansion.
+
+### 40 — Artifact and Metadata Store
+
+- Category:
+  - data persistence
+- Purpose:
+  - Persist source/converted artifacts and job metadata required by lifecycle operations.
+- Responsibilities:
+  - Store uploaded source files and converted outputs with lifecycle policies.
+  - Persist job metadata, status history, and audit-relevant records.
+  - Provide signed/controlled retrieval references for downloads.
+- Interfaces:
+  - Incoming (one per flow)
+    - Type: downstream inputs
+    - Short description: Receives artifact writes and metadata updates from Components 20 and 30.
+  - Outgoing:
+    - Type: downstream outputs
+    - Short description: Serves artifact streams and metadata reads to authorized internal consumers.
+
+- Data / state:
+  - Binary artifacts, metadata records, retention markers, integrity checksums.
+- Interactions:
+  - User-facing:
+    - None directly; enables download via Component 20.
+  - Internal synchronous:
+    - Read/write operations from Components 20 and 30.
+  - Internal asynchronous:
+    - Optional data lifecycle events toward Component 50.
+- Security / access considerations:
+  - Data encryption, scoped access tokens, retention and deletion controls.
+- Observability / operational considerations:
+  - Storage growth tracking, retrieval latency, and corruption/integrity alerting.
+- Dependencies:
+  - 60
+- Constraints / notes:
+  - Must support large file throughput while preserving predictable retrieval performance.
+
+### 50 — Eventing and Work Dispatch Backbone
+
+- Category:
+  - messaging
+- Purpose:
+  - Decouple request handling, conversion execution, and lifecycle updates through asynchronous communication.
+- Responsibilities:
+  - Queue and dispatch conversion work reliably.
+  - Broadcast lifecycle events (submitted, running, completed, failed).
+  - Support retry, dead-letter, and backpressure behaviors.
+- Interfaces:
+  - Incoming (one per flow)
+    - Type: commands/events
+    - Short description: Receives workflow commands and status publications from Components 20 and 30.
+  - Outgoing:
+    - Type: commands/events
+    - Short description: Delivers work items to Component 30 and lifecycle events to Components 20 and 60.
+
+- Data / state:
+  - Message topics/queues, delivery attempts, dead-letter payloads.
+- Interactions:
+  - User-facing:
+    - None directly.
+  - Internal synchronous:
+    - None required by default.
+  - Internal asynchronous:
+    - Central backbone for job dispatch and completion propagation.
+- Security / access considerations:
+  - Producer/consumer authorization boundaries and message integrity validation.
+- Observability / operational considerations:
+  - Queue depth, consumer lag, retry rates, and dead-letter monitoring.
+- Dependencies:
+  - 60
+- Constraints / notes:
+  - Must preserve ordering guarantees where workflow correctness requires it.
+
+### 60 — Security, Policy, and Operational Governance
+
+- Category:
+  - identity and access
+- Purpose:
+  - Provide shared trust, policy enforcement, and operational governance across all components.
+- Responsibilities:
+  - Manage identity context and authorization policies.
+  - Enforce upload limits, retention policies, and abuse controls.
+  - Centralize audit trails, operational policy checks, and compliance signals.
+- Interfaces:
+  - Incoming (one per flow)
+    - Type: upstream inputs/events
+    - Short description: Receives access checks, policy evaluation requests, and audit events from Components 20/40/50.
+  - Outgoing:
+    - Type: responses/events
+    - Short description: Returns authorization decisions and publishes governance alerts.
+
+- Data / state:
+  - Policy definitions, access grants, audit logs, governance configuration.
+- Interactions:
+  - User-facing:
+    - Indirectly shapes access behavior and error messaging.
+  - Internal synchronous:
+    - Policy decision calls from Components 20 and 40.
+  - Internal asynchronous:
+    - Consumes lifecycle/audit events from Component 50.
+- Security / access considerations:
+  - Trust anchor for authorization and audit integrity.
+- Observability / operational considerations:
+  - Security anomaly visibility, policy decision metrics, and audit trail completeness.
+- Dependencies:
+  - 50
+- Constraints / notes:
+  - Governance checks must avoid becoming a throughput bottleneck.
+
+## System interaction summary
 
 - Primary request / control paths:
-  - <summary>
+  - Users submit conversion requests through Component 10 to Component 20.
+  - Component 20 validates, records, and dispatches conversion work through Component 50 to Component 30.
+  - Component 20 returns lifecycle status and download readiness back to Component 10.
 - Primary data flows:
-  - <summary>
+  - Source files flow from Component 10 via Component 20 into Component 40.
+  - Component 30 reads source artifacts from Component 40 and writes converted outputs back to Component 40.
+  - Component 20 provides users controlled access to converted artifacts stored in Component 40.
 - Primary event flows:
-  - <summary>
+  - Component 20 emits job lifecycle events into Component 50.
+  - Component 30 emits execution outcomes into Component 50.
+  - Component 50 routes events to Component 20 and Component 60 for status projection and governance/audit processing.
 
-### System-wide concerns
+## System-wide concerns
 
 - Security and access control:
-  - <items>
+  - Untrusted input handling, authorization on job/artifact access, and tenant/session data isolation.
 - Reliability and recovery:
-  - <items>
+  - Idempotent job processing, retries for transient conversion failures, and dead-letter handling for irrecoverable work items.
 - Observability and operations:
-  - <items>
+  - End-to-end tracing, per-format conversion KPIs, and centralized auditability.
 - Performance and scalability:
-  - <items>
+  - Horizontal scaling for conversion execution, asynchronous decoupling for burst handling, and throughput-aware storage patterns.
 - Compliance / audit / governance:
-  - <items if relevant>
+  - Conversion and download audit trails, retention enforcement, and policy-based data lifecycle management.
 
-### Open questions
-- <question requiring architectural decision>
+## Open questions
 
-### Graph representation
+- Should conversion execution guarantees favor strict in-order processing per user/job group, or maximize throughput with relaxed ordering?
+- What retention window should be the default for source versus converted artifacts in MVP?
+- Is anonymous conversion allowed in MVP, or is authenticated access mandatory from day one?
 
-Provide here a high-level graph representation of the component and the main relationships between them.
+## Graph representation
+
+```mermaid
+flowchart LR
+  U[Browser User] --> C10[10 Web Experience and Session Gateway]
+  C10 --> C20[20 Conversion API and Workflow Coordinator]
+
+  C20 --> C40[40 Artifact and Metadata Store]
+  C20 --> C50[50 Eventing and Work Dispatch Backbone]
+  C50 --> C30[30 Conversion Execution Services]
+  C30 --> C40
+  C30 --> C50
+
+  C50 --> C20
+  C20 --> C10
+
+  C20 --> C60[60 Security, Policy, and Operational Governance]
+  C40 --> C60
+  C50 --> C60
+```

--- a/vibeCoding/.architecture/HISTORY.md
+++ b/vibeCoding/.architecture/HISTORY.md
@@ -8,35 +8,32 @@
 
 ## Completed architecture drafts
 <!-- Append entries as architecture drafts are completed, updated, or approved. -->
-- YYYY-MM-DD — <system or project name>
+- 2026-03-06 — Cloud-native document conversion platform (Arch.0.1)
   - Draft file: `.architecture/ARCHITECTURE_DESCRIPTION.md`
   - Summary:
-    - <major architectural outcome>
-    - <major architectural outcome>
+    - Defined six architectural components covering client access, orchestration, conversion execution, persistence, messaging, and governance.
+    - Captured system interaction paths, cross-cutting concerns, and open decisions needed before approval.
 
 ## Review history
 <!-- Use this for architecture revision rounds -->
-- YYYY-MM-DD — Review round <n>
-  - Architectural components IDs (if relevant): []
+- 2026-03-06 — Review round 1
+  - Architectural components IDs (if relevant): [10, 20, 30, 40, 50, 60]
   - Feedback summary (e.g. from follow-up prompts etc.)
-    - <what changed or was requested>
-  - Result: <accepted | changes requested | blocked>
+    - Initial architecture baseline prepared for human review.
+    - Decision points separated into PLAN items Arch-0.1 and Arch-0.2.
+  - Result: changes requested
 
 ## Resolved issues
 
-- YYYY-MM-DD — ISSUE-001: <title>
-  - Resolution: <1–2 lines>
-  - Notes: <optional>
+- None yet.
 
 ## Architectural decisions
 <!-- Keep only decisions worth preserving across revisions. -->
-- YYYY-MM-DD: <decision>
-  - Architectural components IDs (if relevant): []
-  - Rationale: <1–2 lines>
-  - Impact: <what parts of the architecture this affects>
+- 2026-03-06: Adopted role-based, technology-agnostic component decomposition for architecture baseline.
+  - Architectural components IDs (if relevant): [10, 20, 30, 40, 50, 60]
+  - Rationale: Preserve abstraction level and keep implementation choices open for later stages.
+  - Impact: Enables downstream component design and implementation without vendor lock-in in architecture documents.
 
 ## Superseded assumptions / changes
 <!-- Optional. Use when previous assumptions were later invalidated. -->
-- YYYY-MM-DD: <old assumption or prior direction>
-  - Replaced by: <new direction>
-  - Reason: <why it changed>
+- None.

--- a/vibeCoding/.architecture/PLAN.md
+++ b/vibeCoding/.architecture/PLAN.md
@@ -38,21 +38,44 @@ Each item should contain:
 
 ## Active architecture questions
 
-### Arch-0.0 — <short title>
+### Arch-0.1 — Ordering and dispatch guarantees for conversion workload
 
-- Type: <CLARIFICATION | DECISION | INVESTIGATION | ASSUMPTION_VALIDATION | RISK_REVIEW>
-- Status: <OPEN | IN_PROGRESS | BLOCKED | DECISION_REQUIRED | RESOLVED>
+- Type: DECISION
+- Status: DECISION_REQUIRED
 - Related system / draft:
-  - <system name or architecture draft identifier>
+  - Arch.0.1
 - Why it matters:
-  - <why this question materially affects the architecture>
+  - Dispatch semantics influence throughput, fairness, and predictability for user-visible completion times.
 - Known options / hypotheses:
-  - <option or hypothesis>
+  - Strict ordering by user/session job stream.
+  - Best-effort parallel dispatch with idempotent completion handling.
+  - Hybrid policy (ordered within a narrow scope, parallel globally).
 - Required input / evidence:
-  - <what information, analysis, or human decision is needed>
+  - Product expectation on UX predictability versus raw throughput for MVP.
 - Resolution criteria:
-  - <what must be true for this item to be considered resolved>
+  - Clear rule selected for dispatch/ordering guarantees and reflected in component interaction constraints.
 - Affected sections:
-  - <component ids / architecture sections / document paths>
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` (Components 20, 30, 50; open questions)
 - Notes:
-  - <optional>
+  - Decision can remain provisional for MVP but must be explicit.
+
+### Arch-0.2 — Access model for MVP (anonymous vs authenticated)
+
+- Type: DECISION
+- Status: DECISION_REQUIRED
+- Related system / draft:
+  - Arch.0.1
+- Why it matters:
+  - Authentication requirements materially change security boundaries, retention risk, and abuse controls.
+- Known options / hypotheses:
+  - Anonymous conversion with strict rate and retention limits.
+  - Mandatory authenticated access from day one.
+  - Mixed model: anonymous trial with authenticated higher limits.
+- Required input / evidence:
+  - Product and compliance expectations for user identity, quota management, and auditability.
+- Resolution criteria:
+  - MVP access model chosen and translated into explicit constraints for components 10, 20, and 60.
+- Affected sections:
+  - `.architecture/ARCHITECTURE_DESCRIPTION.md` (Components 10, 20, 60; system-wide concerns)
+- Notes:
+  - Closely related to retention and policy governance requirements.

--- a/vibeCoding/.architecture/STATE.md
+++ b/vibeCoding/.architecture/STATE.md
@@ -19,30 +19,35 @@ This file keeps track of architectural discussions. Mostly when tricker issues n
 ## Current focus
 
 - Revision ID: Arch.0.1
-- Status: NOT_STARTED  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+- Status: IN_REVIEW  <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
 
 ## Objective (current draft)
-<!-- 1 sentence. Keep aligned with `.architecture/ARCHITECTURE_DESCRIPTION.md`. -->
+Define an MVP-friendly cloud-native architecture for browser-driven document and geospatial file conversion using microservice boundaries.
 
 ## Active assumptions / constraints
 <!-- Keep only the assumptions or constraints that materially affect the current architecture draft. -->
-- <assumption or constraint>
+- Cloud-native deployment context.
+- Browser upload and download user journey.
+- Microservice-oriented decomposition.
+- Incremental MVP-first delivery.
+- Media conversion (video/audio/image) remains out of scope.
 
 ## Work log (current session)
 <!-- Append-only bullets for what changed and why. Prefer file/section references. -->
-- YYYY-MM-DD: <change made and reason>
+- 2026-03-06: Created first full architecture draft in `.architecture/ARCHITECTURE_DESCRIPTION.md` with six major components and system-wide concerns.
+- 2026-03-06: Captured unresolved architecture decisions in `.architecture/PLAN.md` to prepare human review.
 
 ## Workflow state
 <!-- Dispatcher flags. Checked = active/needed. Cleared once handled. -->
-- [ ] PROBLEM_CLARIFIED
-- [ ] DRAFT_CREATED
-- [ ] HUMAN_REVIEW_REQUIRED
+- [x] PROBLEM_CLARIFIED
+- [x] DRAFT_CREATED
+- [x] HUMAN_REVIEW_REQUIRED
 - [ ] DECISIONS_CAPTURED
 
 ## Active issues
 <!-- Keep only active issues here. Move resolved items to HISTORY.md. -->
-- [ ] Arch.0.1: <short title>
+- [x] Arch.0.1: Initial architecture baseline review
   - Impact: QUESTION <!-- QUESTION | MINOR | MAJOR | BLOCKER -->
-  - Status: NOT_STARTED <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
-  - Unblock condition: <what must be true to proceed>
-  - Notes: <optional context>
+  - Status: IN_REVIEW <!-- one of: NOT_STARTED | IN_PROGRESS | IN_REVIEW | DONE -->
+  - Unblock condition: Human reviewer confirms open decisions and approves or requests updates.
+  - Notes: Open decision items tracked as Arch-0.1 and Arch-0.2 in `.architecture/PLAN.md`.


### PR DESCRIPTION
### Motivation
- Provide a clear, technology-agnostic architecture draft to guide implementation for a cloud-native document and geospatial file conversion platform. 
- Move the architecture workflow from a template to an actionable baseline so reviewers can validate scope, assumptions, and outstanding decisions.

### Description
- Replaced the previous architecture template with a full `Arch.0.1` draft in `vibeCoding/.architecture/ARCHITECTURE_DESCRIPTION.md` that defines six role-based components (10, 20, 30, 40, 50, 60) with responsibilities, interfaces, interactions, dependencies, and system-wide concerns. 
- Added two decision items to `vibeCoding/.architecture/PLAN.md` (`Arch-0.1` ordering/dispatch guarantees and `Arch-0.2` MVP access model) to capture open architectural choices needing human input. 
- Updated `vibeCoding/.architecture/STATE.md` to set the draft status to `IN_REVIEW` and recorded the current work log and active issue, and recorded the draft and review summary in `vibeCoding/.architecture/HISTORY.md`.
- Committed the four modified files: `ARCHITECTURE_DESCRIPTION.md`, `PLAN.md`, `STATE.md`, and `HISTORY.md` and prepared a PR payload.

### Testing
- Verified repository state with `git -C /workspace/testProject1 status --short` which completed successfully. 
- Verified `git status --short` locally and committed the changes with a commit message, which succeeded. 
- Created the PR payload via the `make_pr` tool and received the PR title/body confirmation indicating the change set was packaged for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab412c6778832eb1daf355de9b091e)